### PR TITLE
Disabled manual addition of zlib when building on non-linux platforms.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,6 @@ extensions = {
 }
 
 libraries = ['png', 'jpeg', 'tiff', 'webp']
-if 'linux' not in sys.platform:
-    libraries.append('zlib')
 
 ext_modules = [
     numpyutils.Extension(


### PR DESCRIPTION
Hi. I was having errors building the latest `imread` sources on OSX from your repo's master:

https://gist.github.com/4023544#file_error_building_luispedro_source_with_pip.txt

Removing the two lines from setup.py that add `zlib` to the libraries install list on non-linux systems fixed it -- all the tests ran OK thereafter and the library performed as advertised:

https://gist.github.com/4023544#file_successful_install_build_ext_inplace_and_nosetests_run_with_patch_to_setup_file.txt

I am not sure if adding `zlib` explicitly is necessary for some other platform, or if indeed this is the way to go, but it was a solution on my end. 
