### PR TITLE
add numpy to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,5 +133,6 @@ setuptools.setup(name = 'imread',
       package_data = package_data,
       cmdclass = {'build_ext': build_ext},
       setup_requires = ['numpy'],
+      install_requires = ['numpy'],
       test_suite = 'nose.collector',
       )


### PR DESCRIPTION
while this does address the dependency issue, it exposes a known issue with setup tools: https://github.com/pypa/setuptools/issues/391

the tradeoff here is increased simplicity for users to install imread as a distributed package at the expense of some potential confusion when running setup.py directly.  Assume the issue is addressed by setuptools down the road it should no longer be a problem here.