### PR TITLE
BUG Fix 16-bit RGB/RGBA PNG write

### DIFF
--- a/imread/_imread.cpp
+++ b/imread/_imread.cpp
@@ -295,7 +295,7 @@ PyObject* py_imsave_may_multi(PyObject* self, PyObject* args, bool is_multi) {
         if (is_multi) {
             image_list array_list;
             const unsigned n = PyList_GET_SIZE(arrays);
-            for (int i = 0; i != n; ++i) {
+            for (int i = 0; i != int(n); ++i) {
                 array = (PyArrayObject*)PyList_GET_ITEM(arrays, i);
                 if (!PyArray_Check(array)) {
                     PyErr_SetString(PyExc_RuntimeError, "imsave_multi: Array expected in list");


### PR DESCRIPTION
This fixes issue #24. There was a bug in converting 16-bit words from x86 byte order to network byte order: Only the first width * height words were swapped, although there are width * height * 3 words in an RGB image (and 4 in case of RGBA).
